### PR TITLE
added json fix

### DIFF
--- a/lib/src/rest/methods.js
+++ b/lib/src/rest/methods.js
@@ -42,6 +42,12 @@ spf.rest.RestApi = function() {
             .then(function (response) {
                 var saveFilePath = downloadRoot + "/" + decodeURIComponent(spFilePath).replace(decodeURIComponent(spFolderBase), "");
                 var saveFolderPath = path.dirname(saveFilePath);
+                if (/.json$/.test(saveFilePath)) {
+                    response.body = JSON.stringify(response.body, null, 4);
+                }
+                if (/.map$/.test(saveFilePath)) {
+                    response.body = JSON.stringify(response.body);
+                }
                 mkdirp(saveFolderPath, function(err) {
                     fs.writeFile(saveFilePath, response.body, function(err) {
                         if (err) {


### PR DESCRIPTION
Files that contain pure json data were not being copied over to the destination correctly.  Any kind of file, .json or .map in this case, that contained pure json would only contain [object Object] after being pulled from the site.  My fork contains a way to fix this using a conditional that checks the extension name of the file before converting it into a string using JSON.stringify.  