### PR TITLE
added regex pattern to only match base tokens against the start of sp…

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -37,7 +37,7 @@ export default class RestAPI {
     return new Promise((resolve, reject) => {
       this.spr = this.getCachedRequest();
 
-      const spBaseFolderRegEx = new RegExp(decodeURIComponent(this.options.spBaseFolder), 'gi');
+      const spBaseFolderRegEx = new RegExp(decodeURIComponent('^' + this.options.spBaseFolder), 'gi');
       let spFilePathRelative = decodeURIComponent(spFilePath);
       if (['', '/'].indexOf(this.options.spBaseFolder) === -1) {
         spFilePathRelative = decodeURIComponent(spFilePath).replace(spBaseFolderRegEx, '');


### PR DESCRIPTION

*Closes*
https://github.com/koltyakov/sppull/issues/27

*Original Issue*
when downloading files, if the filename contains the subsite (`spBaseFolder`) name as a substring of it's filename (`spFilePath`), then that token will be removed from the downloaded file's name or path.

*Resolution*
I updated the regex pattern used when trimming the `spBaseFolder` value from the full `spFilePath` to only match patterns at the beginning of the string. This will prevent incorrectly matching file or folder names later in the `spFilePath` object.

(Sorry this took so long)
