### PR TITLE
Strict object fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ Refer to the [Scenarios](https://github.com/koltyakov/sppull/tree/master/docs/Sc
 ### Basic usage
 
 ```javascript
-var sppull = require("sppull").sppull;
+const { sppull } = require("sppull");
 
-var context = {
+const context = {
   siteUrl: "http://contoso.sharepoint.com/subsite",
   creds: {
     username: "user@contoso.com",
@@ -146,7 +146,7 @@ var context = {
   }
 };
 
-var options = {
+const options = {
   spRootFolder: "Shared%20Documents/Contracts",
   dlRootFolder: "./Downloads/Contracts"
 };
@@ -157,11 +157,11 @@ var options = {
  * Folders structure will remain original as it is in SharePoint's target folder.
 */
 sppull(context, options)
-  .then(function(downloadResults) {
+  .then((downloadResults) => {
     console.log("Files are downloaded");
     console.log("For more, please check the results", JSON.stringify(downloadResults));
   })
-  .catch(function(err) {
+  .catch((err) => {
     console.log("Core error has happened", err);
   });
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sppull",
   "description": "Download files from SharePoint document libraries using Node.js without hassles",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "author": "Andrew Koltyakov <andrew.koltyakov@gmail.com>",
   "main": "./dist/index.js",
   "typings": "./dist/index",

--- a/src/SPPull.ts
+++ b/src/SPPull.ts
@@ -219,7 +219,7 @@ export class Download {
 
   private async runDownloadStrictObjects(ctx: ICtx) {
     const filesList: IFileBasicMetadata[] = ctx.options.strictObjects
-      .filter((d) => d.split('/').slice(-1).indexOf('.') !== -1)
+      .filter((d) => d.split('/').slice(-1)[0].indexOf('.') !== -1)
       .map((ServerRelativeUrl) => ({ ServerRelativeUrl }));
 
     if (filesList.length > 0) {


### PR DESCRIPTION
Change the `strictObject` filter to check that the file path contains the character '.', rather than checking to see if the file path is equal to '.'.

Referencing (closes #34): https://github.com/koltyakov/sppull/issues/34

