### PR TITLE
Pin colors version to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "mkdirp": "^1.0.4",
     "node-sp-auth": "^3.0.4",
     "node-sp-auth-config": "^3.0.1",


### PR DESCRIPTION
In order to avoid the Marak bug, I pinned the version of `colors` dependency.
